### PR TITLE
News cache

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/AppResources.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/AppResources.kt
@@ -1,5 +1,6 @@
 package com.github.csc3380fall2024.team16
 
+import com.github.csc3380fall2024.team16.repository.NewsRepository
 import com.github.csc3380fall2024.team16.repository.SessionRepository
 import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
@@ -12,4 +13,5 @@ class AppResources(backendUrl: Url, appDir: String) {
         pathSegments = listOf("rpc")
     }.build())
     val sessionRepo = SessionRepository(client, Path(appDir, "session"))
+    val newsRepo = NewsRepository(client, Path(appDir, "news"))
 }

--- a/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/repository/NewsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/repository/NewsRepository.kt
@@ -1,0 +1,31 @@
+package com.github.csc3380fall2024.team16.repository
+
+import com.github.csc3380fall2024.team16.RpcClient
+import com.github.csc3380fall2024.team16.model.NewsArticle
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.extensions.updatesOrEmpty
+import io.github.xxfast.kstore.file.extensions.listStoreOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.io.files.Path
+
+class NewsRepository(private val client: RpcClient, path: Path) {
+    private val store: KStore<List<Pair<String, List<NewsArticle>>>> = listStoreOf(file = path)
+    
+    val updates = store.updatesOrEmpty.stateIn(CoroutineScope(Job()), SharingStarted.Eagerly, emptyList())
+    
+    suspend fun fetch(token: String, vararg queries: String) = coroutineScope {
+        val tasks = queries.map { query ->
+            async {
+                query to client.rpc { getNewsArticles(token, query) }
+            }
+        }
+        
+        store.set(tasks.awaitAll())
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/ui/routes/root/authenticated/news/NewsRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/ui/routes/root/authenticated/news/NewsRoute.kt
@@ -1,6 +1,9 @@
 package com.github.csc3380fall2024.team16.ui.routes.root.authenticated.news
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.csc3380fall2024.team16.AppResources
 import kotlinx.serialization.Serializable
@@ -10,6 +13,14 @@ data class NewsRoute(val token: String)
 
 @Composable
 fun NewsRoute.compose(app: AppResources) {
-    val viewModel = viewModel { NewsViewModel(app.client, token) }
-    NewsScreen(viewModel.state)
+    val articles by app.newsRepo.updates.collectAsState()
+    
+    val viewModel = viewModel { NewsViewModel(app.newsRepo, token) }
+    LaunchedEffect(Unit) {
+        viewModel.fetch("Fitness, exercise, and lifting", "Sports", "Health and body")
+    }
+    NewsScreen(
+        articles = articles,
+        error = viewModel.error,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/ui/routes/root/authenticated/news/NewsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/ui/routes/root/authenticated/news/NewsScreen.kt
@@ -1,7 +1,9 @@
 package com.github.csc3380fall2024.team16.ui.routes.root.authenticated.news
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -35,28 +38,29 @@ import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.until
 
 @Composable
-fun NewsScreen(state: NewsState) {
-    
+fun NewsScreen(
+    articles: List<Pair<String, List<NewsArticle>>>,
+    error: Boolean,
+) {
     val scrollState = rememberScrollState()
     val coroutineScope = rememberCoroutineScope()
     
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(scrollState)
-    ) {
-        FunFactOfDay()
-        
-        Spacer(modifier = Modifier.height(24.dp))
-        
-        if (state is NewsState.Loaded) {
-            state.articles.forEach { (query, articles) ->
+    Box {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+        ) {
+            FunFactOfDay()
+            
+            Spacer(modifier = Modifier.height(24.dp))
+            
+            articles.forEach { (query, articles) ->
                 NewsSection(
                     sectionTitle = query,
                     articles = articles
                 )
             }
-            
             
             Button(
                 modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -71,6 +75,23 @@ fun NewsScreen(state: NewsState) {
             }
             
             Spacer(modifier = Modifier.height(16.dp))
+        }
+        
+        if (error) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .offset(y = (-10).dp)
+                    .clip(RoundedCornerShape(80.dp)),
+            ) {
+                Text(
+                    text = "There was an error fetching news.",
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.errorContainer)
+                        .padding(20.dp),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/ui/routes/root/authenticated/news/NewsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/csc3380fall2024/team16/ui/routes/root/authenticated/news/NewsViewModel.kt
@@ -5,39 +5,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.csc3380fall2024.team16.RpcClient
-import com.github.csc3380fall2024.team16.model.NewsArticle
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import com.github.csc3380fall2024.team16.repository.NewsRepository
 import kotlinx.coroutines.launch
 
-sealed interface NewsState {
-    data object Loading : NewsState
-    data class Loaded(val articles: List<Pair<String, List<NewsArticle>>>) : NewsState
-    data class Error(val exception: Exception) : NewsState
-}
-
-class NewsViewModel(private val client: RpcClient, private val token: String) : ViewModel() {
-    var state: NewsState by mutableStateOf(NewsState.Loading)
-        private set
-    
-    init {
-        fetch("Fitness, exercise, and lifting", "Sports", "Health and body")
-    }
-    
-    private fun fetch(vararg queries: String) {
-        val tasks = queries.map { query ->
-            viewModelScope.async {
-                query to client.rpc { getNewsArticles(token, query) }
-            }
-        }
-        
-        viewModelScope.launch {
-            state = try {
-                NewsState.Loaded(tasks.awaitAll())
-            } catch (e: Exception) {
-                NewsState.Error(e)
-            }
-        }
-    }
+class NewsViewModel(private val newsRepo: NewsRepository, private val token: String) : ViewModel() {
+	var error by mutableStateOf(false)
+		private set
+	
+	fun fetch(vararg queries: String) = viewModelScope.launch {
+		try {
+			newsRepo.fetch(token, *queries)
+			error = false
+		} catch (e: Exception) {
+			error = true
+		}
+	}
 }

--- a/server/src/main/kotlin/com/github/csc3380fall2024/team16/Application.kt
+++ b/server/src/main/kotlin/com/github/csc3380fall2024/team16/Application.kt
@@ -2,6 +2,7 @@ package com.github.csc3380fall2024.team16
 
 import com.github.csc3380fall2024.team16.plugins.configureDatabase
 import com.github.csc3380fall2024.team16.plugins.configureRpc
+import com.github.csc3380fall2024.team16.repository.NewsRepository
 import com.github.csc3380fall2024.team16.server.BuildConfig
 import io.ktor.server.application.Application
 import io.ktor.server.cio.CIO
@@ -19,5 +20,7 @@ fun main() {
 
 fun Application.module() {
     configureDatabase()
-    configureRpc()
+    
+    val newsRepo = NewsRepository(BuildConfig.BING_SEARCH_API_KEY)
+    configureRpc(newsRepo)
 }


### PR DESCRIPTION
News will be cached on both the server and client now.
The server will keep a cache of the news pages in memory for 3 hours to avoid spamming Bing with requests.
The client will still request the backend on every navigation to the news screen, but will still cache news articles and display them.